### PR TITLE
Potential fix for code scanning alert no. 6: Incomplete multi-character sanitization

### DIFF
--- a/supabase/functions/analyze-schema-patch/index.ts
+++ b/supabase/functions/analyze-schema-patch/index.ts
@@ -183,7 +183,13 @@ function extractStructuredData(html: string) {
   if (jsonLdMatches) {
     jsonLdMatches.forEach(match => {
       try {
-        const jsonContent = match.replace(/<script[^>]*>/i, '').replace(/<\/script>/i, '').trim()
+        let jsonContent = match.trim();
+        let previous;
+        do {
+          previous = jsonContent;
+          jsonContent = jsonContent.replace(/<script[^>]*>/i, '').replace(/<\/script>/i, '');
+        } while (jsonContent !== previous);
+        jsonContent = jsonContent.trim();
         const parsed = JSON.parse(jsonContent)
         schemas.push(parsed)
       } catch (e) {


### PR DESCRIPTION
Potential fix for [https://github.com/Digital-Frontier-Company/generative-search-pro/security/code-scanning/6](https://github.com/Digital-Frontier-Company/generative-search-pro/security/code-scanning/6)

To address the issue, we should ensure that all occurrences of the `<script>` opening and closing tags are removed from the input before processing it. This can be achieved by repeatedly applying the replacement until no further changes occur. This approach ensures that nested or malformed `<script>` tags are fully sanitized. Additionally, we can consider using a well-tested library like `sanitize-html` if external dependencies are acceptable.

The fix involves:
1. Implementing a loop to repeatedly replace `<script>` opening and closing tags until the input stabilizes.
2. Updating the sanitization logic within the `extractStructuredData` function to handle the replacement iteratively.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
